### PR TITLE
Add Makefile to build without XCode (just type make).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+all:
+	cc -o secure-notes-exporter/secure-notes-exporter -framework CoreFoundation -framework Security secure-notes-exporter/main.c


### PR DESCRIPTION
Hi, I found your project and it was the only thing I could find that easily exported all my secure notes to a text file. Thanks! To build it without XCode I'm adding a simple Makefile. Tested on macOS 10.14.6 (Mojave).